### PR TITLE
Disable certificate check when downloading from kernel.org

### DIFF
--- a/provisioners/scripts/centos/install_centos7_git.sh
+++ b/provisioners/scripts/centos/install_centos7_git.sh
@@ -21,7 +21,7 @@ mkdir -p /usr/local/src/git
 cd /usr/local/src/git
 
 # download git source from kernel.org.
-wget --no-verbose https://www.kernel.org/pub/software/scm/git/${gitbinary}
+wget --no-verbose --no-check-certificate https://www.kernel.org/pub/software/scm/git/${gitbinary}
 
 # extract git source.
 tar -zxvf ${gitbinary} --no-same-owner --no-overwrite-dir
@@ -58,7 +58,7 @@ mkdir -p /usr/share/man
 cd /usr/share/man
 
 # download git man pages from kernel.org.
-wget --no-verbose https://www.kernel.org/pub/software/scm/git/${gitmanbinary}
+wget --no-verbose --no-check-certificate https://www.kernel.org/pub/software/scm/git/${gitmanbinary}
 
 # extract git man pages.
 tar -zxvf ${gitmanbinary} --no-same-owner --no-overwrite-dir


### PR DESCRIPTION
When building AMI manually, I get the following error due to an expired certificate on kernel.org.
Disabling the certificate checking lets me complete the process - hence the changes.


-- Error --
==> amazon-ebs: + wget --no-verbose https://www.kernel.org/pub/software/scm/git/git-2.26.2.tar.gz
==> amazon-ebs: ERROR: cannot verify www.kernel.org's certificate, issued by ‘/C=FR/ST=Paris/L=Paris/O=Gandi/CN=Gandi Standard SSL CA 2’:
==> amazon-ebs:   Issued certificate has expired.
==> amazon-ebs: To connect to www.kernel.org insecurely, use `--no-check-certificate'.
==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
==> amazon-ebs: Terminating the source AWS instance...
==> amazon-ebs: Cleaning up any extra volumes...
==> amazon-ebs: No volumes to clean up, skipping
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored: Script exited with non-zero exit status: 5.Allowed exit codes are: [0]

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Script exited with non-zero exit status: 5.Allowed exit codes are: [0]

==> Builds finished but no artifacts were created.**